### PR TITLE
deps: Update yamlfmt version

### DIFF
--- a/tools/yamlfmt/melange.yaml
+++ b/tools/yamlfmt/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: yamlfmt
-  version: 0.11.0
+  version: 0.12.0
   description: google/yamlfmt image.
   target-architecture:
     - all

--- a/tools/yamlfmt/melange.yaml
+++ b/tools/yamlfmt/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: yamlfmt
-  version: 0.12.1
+  version: 0.13.0
   description: google/yamlfmt image.
   target-architecture:
     - all

--- a/tools/yamlfmt/melange.yaml
+++ b/tools/yamlfmt/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: yamlfmt
-  version: 0.12.0
+  version: 0.12.1
   description: google/yamlfmt image.
   target-architecture:
     - all

--- a/tools/yamlfmt/melange.yaml
+++ b/tools/yamlfmt/melange.yaml
@@ -1,6 +1,6 @@
 package:
   name: yamlfmt
-  version: 0.10.0
+  version: 0.11.0
   description: google/yamlfmt image.
   target-architecture:
     - all
@@ -10,7 +10,6 @@ package:
         - "*"
   dependencies:
     runtime: []
-
 environment:
   contents:
     repositories:
@@ -19,7 +18,6 @@ environment:
     packages:
       - apk-tools
       - go
-
 pipeline:
   - name: Update registries
     runs: apk update


### PR DESCRIPTION


Update yamlfmt version

---



<Actions>
    <action id="a8e6c834ae9a88189950e6e4b793b651767b20037d5c18c3a0edbd1b3687fcb7">
        <h3>update yamlfmt version</h3>
        <details id="cd4e6792a55989f34c27a06384e6b7124cbbd015b437ef3e48b0ac7ca30e3070">
            <summary>Bump yamlfmt version</summary>
            <p>change detected:&#xA;&#x9;* key &#34;$.package.version&#34; updated from &#34;0.12.1&#34; to &#34;0.13.0&#34;, in file &#34;tools/yamlfmt/melange.yaml&#34;</p>
            <details>
                <summary>0.11.0</summary>
                <pre>&#xA;Release published on the 2024-02-10 14:39:34 +0000 UTC at the url https://github.com/google/yamlfmt/releases/tag/v0.11.0&#xA;&#xA;# Oops, all features!&#xD;&#xA;&#xD;&#xA;https://www.youtube.com/watch?v=cXBX2PumuBk&#xD;&#xA;&#xD;&#xA;It&#39;s been a while since the last release! Life has kept me very busy, but since there were a number of feature requests in the issue queue that weren&#39;t too challenging to implement I knocked a bunch of them off the list! I also came up with one feature for this release myself.&#xD;&#xA;&#xD;&#xA;## Config Discovery Enhancements&#xD;&#xA;&#xD;&#xA;Two major enhancements to config discovery! I am pretty sure they are purely additive and shouldn&#39;t break any existing workflows, but don&#39;t hesitate to open an issue if there&#39;s something I missed.&#xD;&#xA;&#xD;&#xA;### Config file can be `.yamlfmt`, `yamlfmt.yaml`, or `yamlfmt.yml`&#xD;&#xA;&#xD;&#xA;Instead of forcing the `.yamlfmt` hidden file name, the command will also recognize `yamlfmt.yaml` or `yamlfmt.yml` as a valid file name. (Note that this only applies to automatic config searching; it has never mattered what the name of a file specified directly in the `-conf` flag is.)&#xD;&#xA;&#xD;&#xA;### Config file search goes all the way up the directory tree&#xD;&#xA;&#xD;&#xA;Instead of only looking for a yamlfmt config in the working directory, it will look at every directory up from the current directory and use the nearest config file it can find. If it doesn&#39;t find one all the way up the tree, then it will default to the config file in the global location at `$XDG_CONFIG_HOME/yamlfmt` (`LOCALAPPDATA` on Windows). This should be useful for monorepo scenarios, where you might want to apply a single `yamlfmt` config file to a number of projects within the monorepo, instead of needing a config file in every sub-project or having to manually specify with `-conf`.&#xD;&#xA;&#xD;&#xA;This does change some potential scenarios where previously the global config would have been discovered. To combat this, I added a new command line flag `-global_conf` that will force using the config from the global location.  &#xD;&#xA;Similarly, I added `-no_global_conf` to force not using the global config.&#xD;&#xA;&#xD;&#xA;## Use a `.gitignore` for excludes&#xD;&#xA;&#xD;&#xA;The `-gitignore_excludes` or `gitignore_excludes` top-level config option will allow `yamlfmt` to use patterns from a `.gitignore` file for excluding files from formatting! This should be helpful for scenarios where you previously would have needed to repeat all of these patterns in your own `yamlfmt` excludes config. You can also specify a specific path to a `.gitignore` file with `-gitignore_path` or `gitignore_path` (command/config respectively).&#xD;&#xA;&#xD;&#xA;## Retain only single line breaks&#xD;&#xA;&#xD;&#xA;Sometimes you have yaml files where there are lots of line breaks in a row. Sometimes you want to keep those, but sometimes you only want to keep a single one out of a group. The new formatter-level config option `retain_line_breaks_single` will make it so this:&#xD;&#xA;```yaml&#xD;&#xA;a: 1&#xD;&#xA;&#xD;&#xA;&#xD;&#xA;b: 2&#xD;&#xA;```&#xD;&#xA;Formats to this:&#xD;&#xA;```yaml&#xD;&#xA;a: 1&#xD;&#xA;&#xD;&#xA;b: 2&#xD;&#xA;```&#xD;&#xA;&#xD;&#xA;## Debug Logging&#xD;&#xA;&#xD;&#xA;(This is the one I came up with)&#xD;&#xA;&#xD;&#xA;By default `yamlfmt` is deliberately very quiet on output. This did have a negative though, as even in verbose mode it was hard to figure out which config file was used, or why files may have been excluded/included in formatting. Introducing the `-debug` command line flag! Currently there are two debug logging profiles:&#xD;&#xA;&#xD;&#xA;* The `config` profile will log the config file discovery process so you can figure out which config file was used and why&#xD;&#xA;* The `paths` profile will log the include/exclude process to understand exactly which paths are included/excluded and why&#xD;&#xA;&#xD;&#xA;Read more about usage in the docs: https://github.com/google/yamlfmt/blob/v0.11.0/docs/command-usage.md#debug-logging&#xD;&#xA;&#xD;&#xA;# Conclusion&#xD;&#xA;&#xD;&#xA;I knocked out a good number of the issues that aren&#39;t rooted in the yaml parsing/formatting portion of the tool (only one outlier that I&#39;ll address soon). This means my future focus is on how to solve some of the weird yaml problems. Right now it is looking like the main way for me to address these issues is by finally biting the bullet and writing my own. I decided to address a number of features this release to make sure I don&#39;t leave open issues out to dry while I dive into this new challenge.&#xD;&#xA;&#xD;&#xA;As always, don&#39;t hesitate to open an issue if you have any problems!&#xD;&#xA;</pre>
            </details>
            <details>
                <summary>0.12.0</summary>
                <pre>&#xA;Release published on the 2024-05-03 15:37:23 +0000 UTC at the url https://github.com/google/yamlfmt/releases/tag/v0.12.0&#xA;&#xA;# Output Format Release&#xD;&#xA;&#xD;&#xA;I have unfortunately been dealing with a long-running health problem that has made it difficult to do much work on this or any projects for the past couple of months. I did manage to get together some small features and fixes worth noting.&#xD;&#xA;&#xD;&#xA;# Features&#xD;&#xA;&#xD;&#xA;## Output Format&#xD;&#xA;&#xD;&#xA;You can now choose different output formats for lint/dry run. The first alternate output format added is `line`, which makes it so instead of the full detailed output, yamlfmt outputs single lines for each file with formatting differences. This should allow for easier integration into tools like [reviewdog](https://github.com/reviewdog/reviewdog). I have never used that tool, but if anyone is able to get an integration working, feel free to open a Discussion thread about it and let me know!&#xD;&#xA;&#xD;&#xA;## More config file name options&#xD;&#xA;&#xD;&#xA;Last release, I added configuration file naming options to have the yaml extension, i.e. `yamlfmt.yaml` and `yamlfmt.yml`. The way I did that made it so you couldn&#39;t have config files with extension also be hidden. That is resolved now, so you can have `.yamlfmt.yaml` etc.&#xD;&#xA;&#xD;&#xA;# Bug Fixes&#xD;&#xA;&#xD;&#xA;## Don&#39;t write files if there is no diff&#xD;&#xA;&#xD;&#xA;Previously, yamlfmt would always write all files set for formatting even when there would be no change. This meant the edited date of the file was always being updated even though nothing was meant to change. That should not happen anymore.&#xD;&#xA;&#xD;&#xA;## Fix `-global_conf` not working as documented&#xD;&#xA;&#xD;&#xA;The `-global_conf` flag was not working as documented in the last release. If there was a local config, `-global_conf` would end up being ignored and the local config would be used first. This was not the intended functionality and it has been fixed. &#xD;&#xA;&#xD;&#xA;# Contributors&#xD;&#xA;&#xD;&#xA;Thanks @kiliantyler for the catching the global configuration bug and opening a fix for it!&#xD;&#xA;&#xD;&#xA;# 1k stars!&#xD;&#xA;&#xD;&#xA;Thank you very much for over 1000 stars on GitHub! I appreciate the support, and I hope the tool continues to be useful to the community!</pre>
            </details>
            <details>
                <summary>0.12.1</summary>
                <pre>&#xA;Release published on the 2024-05-04 13:20:00 +0000 UTC at the url https://github.com/google/yamlfmt/releases/tag/v0.12.1&#xA;&#xA;# Fix stdin output&#xD;&#xA;&#xD;&#xA;I made a mistake in the last release that caused the `stdin` operation to output a byte array instead of a properly casted string. I will add integration tests to save this from happening in the future.&#xD;&#xA;&#xD;&#xA;**Known Issue**: I was in a rush to get this out when I saw it and forgot to manually update the version string, so `yamlfmt -version` will print `v0.12.0` for this version.&#xD;&#xA;&#xD;&#xA;# [v0.12.0](https://github.com/google/yamlfmt/releases/tag/v0.12.0) Release notes below.&#xD;&#xA;-----&#xD;&#xA;# Output Format Release&#xD;&#xA;I have unfortunately been dealing with a long-running health problem that has made it difficult to do much work on this or any projects for the past couple of months. I did manage to get together some small features and fixes worth noting.&#xD;&#xA;&#xD;&#xA;# Features&#xD;&#xA;&#xD;&#xA;## Output Format&#xD;&#xA;You can now choose different output formats for lint/dry run. The first alternate output format added is line, which makes it so instead of the full detailed output, yamlfmt outputs single lines for each file with formatting differences. This should allow for easier integration into tools like [reviewdog](https://github.com/reviewdog/reviewdog). I have never used that tool, but if anyone is able to get an integration working, feel free to open a Discussion thread about it and let me know!&#xD;&#xA;&#xD;&#xA;## More config file name options&#xD;&#xA;Last release, I added configuration file naming options to have the yaml extension, i.e. yamlfmt.yaml and yamlfmt.yml. The way I did that made it so you couldn&#39;t have config files with extension also be hidden. That is resolved now, so you can have .yamlfmt.yaml etc.&#xD;&#xA;&#xD;&#xA;# Bug Fixes&#xD;&#xA;## Don&#39;t write files if there is no diff&#xD;&#xA;Previously, yamlfmt would always write all files set for formatting even when there would be no change. This meant the edited date of the file was always being updated even though nothing was meant to change. That should not happen anymore.&#xD;&#xA;&#xD;&#xA;## Fix -global_conf not working as documented&#xD;&#xA;The -global_conf flag was not working as documented in the last release. If there was a local config, -global_conf would end up being ignored and the local config would be used first. This was not the intended functionality and it has been fixed.&#xD;&#xA;&#xD;&#xA;# Contributors&#xD;&#xA;Thanks @kiliantyler for the catching the global configuration bug and opening a fix for it!&#xD;&#xA;&#xD;&#xA;# 1k stars!&#xD;&#xA;Thank you very much for over 1000 stars on GitHub! I appreciate the support, and I hope the tool continues to be useful to the community!</pre>
            </details>
            <details>
                <summary>0.13.0</summary>
                <pre>&#xA;Release published on the 2024-06-24 16:12:48 +0000 UTC at the url https://github.com/google/yamlfmt/releases/tag/v0.13.0&#xA;&#xA;</pre>
            </details>
        </details>
        <a href="https://github.com/mecha-ci/images/actions/runs/8583565241">GitHub Action workflow link</a>
    </action>
</Actions>

---

<table>
  <tr>
    <td width="77">
      <img src="https://www.updatecli.io/images/updatecli.png" alt="Updatecli logo" width="50" height="50">
    </td>
    <td>
      <p>
        Created automatically by <a href="https://www.updatecli.io/">Updatecli</a>
      </p>
      <details><summary>Options:</summary>
        <br />
        <p>Most of Updatecli configuration is done via <a href="https://www.updatecli.io/docs/prologue/quick-start/">its manifest(s)</a>.</p>
        <ul>
          <li>If you close this pull request, Updatecli will automatically reopen it, the next time it runs.</li>
          <li>If you close this pull request and delete the base branch, Updatecli will automatically recreate it, erasing all previous commits made.</li>
        </ul>
        <p>
          Feel free to report any issues at <a href="https://github.com/updatecli/updatecli/issues">github.com/updatecli/updatecli</a>.<br />
          If you find this tool useful, do not hesitate to star <a href="https://github.com/updatecli/updatecli/stargazers">our GitHub repository</a> as a sign of appreciation, and/or to tell us directly on our <a href="https://matrix.to/#/#Updatecli_community:gitter.im">chat</a>!
        </p>
      </details>
    </td>
  </tr>
</table>

